### PR TITLE
Minor: ran cargo clippy --fix

### DIFF
--- a/examples/kenney.rs
+++ b/examples/kenney.rs
@@ -47,7 +47,7 @@ fn print_on_load(
     info!("image {:?}", kenney_sheet.sheet);
     info!(
         "first texture: {:?}",
-        kenney_sheet.textures.iter().next()
+        kenney_sheet.textures.first()
     );
 
     commands.spawn(Camera2dBundle::default());

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -102,13 +102,7 @@ fn player_movement_system(
     if keyboard_input.pressed(KeyCode::Space) {
         let can_shoot = last_shot.is_none() || {
             if let Some(shot) = *last_shot {
-                if time.elapsed() - shot
-                    > Duration::from_millis(200)
-                {
-                    true
-                } else {
-                    false
-                }
+                time.elapsed() - shot > Duration::from_millis(200)
             } else {
                 false
             }
@@ -119,7 +113,7 @@ fn player_movement_system(
 
             commands.spawn((
                 SpriteBundle {
-                    transform: transform.clone(),
+                    transform: *transform,
                     texture: space_sheet.sheet.clone(),
                     ..default()
                 },
@@ -129,7 +123,7 @@ fn player_movement_system(
                         .clone(),
                     index: 105,
                 },
-                Laser(movement_factor.clone()),
+                Laser(**movement_factor),
                 Collider::triangle(
                     Vec2::new(0., -27.),
                     Vec2::new(4.5, 27.),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub fn start_game(
 
     commands.spawn(MeteorBundle::big(
         Transform::from_xyz(50., 0., 1.),
-        &space_sheet,
+        space_sheet,
     ));
 }
 

--- a/src/meteors.rs
+++ b/src/meteors.rs
@@ -208,7 +208,7 @@ fn sandbox_meteor_destroyed_event_handler(
                                 + y as f32,
                             1.,
                         ),
-                        &space_sheet,
+                        space_sheet,
                     ));
                 }
             }
@@ -226,7 +226,7 @@ fn sandbox_meteor_destroyed_event_handler(
                                 + y as f32,
                             1.,
                         ),
-                        &space_sheet,
+                        space_sheet,
                     ));
                 }
             }
@@ -244,7 +244,7 @@ fn sandbox_meteor_destroyed_event_handler(
                     Transform::from_xyz(
                         x as f32, y as f32, 1.,
                     ),
-                    &space_sheet,
+                    space_sheet,
                 ));
             }
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -83,7 +83,7 @@ fn change_menu(
 }
 
 fn audio_state(
-    mut commands: Commands,
+    commands: Commands,
     mut interaction_query: Query<
         (&Interaction, &mut UiImage),
         (

--- a/src/ui/choose_ship.rs
+++ b/src/ui/choose_ship.rs
@@ -170,7 +170,7 @@ pub fn choose_ship_button_system(
 
                 choose_ship_events.send(ChooseShipEvent {
                     ship_type: ship_type.clone(),
-                    ship_menu_location: transform.clone(),
+                    ship_menu_location: *transform,
                 });
                 next_state.set(GameState::Playing);
             }


### PR DESCRIPTION
Manually reivewed all the changes..

In summary, nothing major - two things of note.

1) calls to .clone() were removed in a couple of places.

2)  less function calls.

```
-        kenney_sheet.textures.iter().next()
+        kenney_sheet.textures.first()
```