### PR TITLE
meteors.rs - Move rng definition to a points outside of a couple of for loops.

### DIFF
--- a/src/meteors.rs
+++ b/src/meteors.rs
@@ -188,6 +188,8 @@ fn sandbox_meteor_destroyed_event_handler(
         return;
     };
 
+    let mut rng = rand::thread_rng();
+
     for MeteorDestroyed {
         destroyed_at,
         destroyed_type,
@@ -197,7 +199,6 @@ fn sandbox_meteor_destroyed_event_handler(
             MeteorType::Big => {
                 // become two medium
                 for _ in 0..2 {
-                    let mut rng = rand::thread_rng();
                     let x: i32 = rng.gen_range(-5..5);
                     let y: i32 = rng.gen_range(-5..5);
                     commands.spawn(MeteorBundle::medium(
@@ -215,7 +216,6 @@ fn sandbox_meteor_destroyed_event_handler(
             MeteorType::Medium => {
                 // become two smol
                 for _ in 0..2 {
-                    let mut rng = rand::thread_rng();
                     let x: i32 = rng.gen_range(-5..5);
                     let y: i32 = rng.gen_range(-5..5);
                     commands.spawn(MeteorBundle::small(
@@ -232,7 +232,6 @@ fn sandbox_meteor_destroyed_event_handler(
             }
             MeteorType::Small => {
                 // do nothing
-                let mut rng = rand::thread_rng();
                 let x: i32 = rng.gen_range(
                     (-width as i32 / 2)..(width as i32 / 2),
                 );


### PR DESCRIPTION
I love this little demo...I am learning alot ... I noticed this blemish while crawling over the code.

We can de less work if we define rng once per function call.

```
let mut rng = rand::thread_rng();
```
I have not profiled this code, to see if it is on a hot path - so I am uncertain that it will make a difference.

 .. but I am relying on the principle of doing less work is always good.